### PR TITLE
Feat: Allow setting extra watch dirs and temp location

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const chokidar = require('chokidar')
 const puppeteer = require('puppeteer')
 const { performance } = require('perf_hooks')
 const path = require('path')
+const fs = require('fs')
 const converters = require('./converters.js')
 
 var input, output
@@ -13,20 +14,38 @@ program
   .version('0.0.1')
   .usage('<input> [output] [options]')
   .arguments('<input> [output] [options]')
-  .option('-w, --watch', 'option description')
+  .option('-w, --watch <locations>', 'Watch other locations', [])
+  .option('-t, --temp [location]', 'Directory for temp file')
   .action(function (inp, out) {
     input = inp
     output = out
   })
 
 program.parse(process.argv)
-if (!output) {
-  output = input.substr(0, input.lastIndexOf('.')) + '.pdf'
+
+if (!input) {
+  console.error('Please specifiy an input file');
+  process.exit(1)
 }
+
 const inputPath = path.resolve(input)
-const outputPath = path.resolve(output)
 const inputDir = path.resolve(inputPath, '..')
-const tempHTML = path.join(inputDir, '_temp.htm')
+const inputFilename = input.substr(0, input.lastIndexOf('.'));
+
+if (!output) {
+  output = inputFilename + '.pdf'
+}
+
+const outputPath = path.resolve(output)
+
+const tempHTMLPath = path.join((program.temp 
+                                && fs.existsSync(program.temp) 
+                                && fs.statSync(program.temp).isDirectory()) ? program.temp : inputDir, inputFilename + '_temp.htm')
+
+let watchLocations = [inputDir];
+if (program.watch) {
+  watchLocations = watchLocations.concat(program.watch);
+}
 
 async function main () {
   console.log('Watching ' + input + ' and its directory tree.')
@@ -40,23 +59,22 @@ async function main () {
     console.log('Error: ' + err.toString())
   })
 
-  chokidar.watch(inputDir, {
+  chokidar.watch(watchLocations, {
     awaitWriteFinish: {
       stabilityThreshold: 50,
       pollInterval: 100
     }
   }).on('change', (filepath) => {
-    var shortFilepath = filepath.slice(inputDir.length, filepath.length)
     if (!(['.pug', '.md', '.html', '.css', '.scss', '.svg', '.mermaid',
            '.chart.js', '.png', '.flowchart', '.flowchart.json',
            '.vegalite.json', '.table.csv', 'htable.csv'].some(ext => filepath.endsWith(ext)))) {
       return
     }
-    console.log(`\nProcessing detected change in ${shortFilepath}...`.magenta.bold)
+    console.log(`\nProcessing detected change in ${filepath.replace(inputDir, '')}...`.magenta.bold)
     var t0 = performance.now()
     var taskPromise = null
     if (['.pug', '.md', '.html', '.css', '.scss', '.svg', '.png'].some(ext => filepath.endsWith(ext))) {
-      taskPromise = converters.masterDocumentToPDF(inputPath, page, tempHTML, outputPath)
+      taskPromise = converters.masterDocumentToPDF(inputPath, page, tempHTMLPath, outputPath)
     } else if (filepath.endsWith('.chart.js')) {
       taskPromise = converters.chartjsToPNG(filepath, page)
     } else if (filepath.endsWith('.mermaid')) {


### PR DESCRIPTION
My use case is that I have multiple .pug files that I want to work on, and some shared assets (styles/images etc).

Rather than having to duplicate the assets, or create symlinks the ```--watch``` option can be used to specify multiple places to watch files for updates.

Also being able to set the temp directory means that I don't end up with lots of .htm files lying around my working directory.

```
relaxed my_first_doc.pug output/other_thing.pdf --watch ../assets/style/theme.scss --temp /tmp
```