### PR TITLE
Feat: Use old version of chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ At the moment, the best solution is to install ReLaXed in an empty directory as 
 
 ```
 git clone https://github.com/RelaxedJS/ReLaXed.git .
-npm install
+export PUPPETEER_CHROMIUM_REVISION=526987 && npm install
 sudo npm link --unsafe-perm=true
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "author": "Zulko",
   "homepage": "https://github.com/RelaxedJS",
   "license": "ISC",
+  "puppeteer": {
+    "chromium_revision": "526987"
+  },
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "chokidar": "^2.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ const { performance } = require('perf_hooks')
 const path = require('path')
 const converters = require('./converters.js')
 
+const chromiumRevision = process.env.PUPPETEER_CHROMIUM_REVISION
+                         || process.env.npm_config_puppeteer_chromium_revision
+                         || require('../package.json').puppeteer.chromium_revision
+
 var input, output
 
 program
@@ -30,8 +34,12 @@ const tempHTML = path.join(inputDir, '_temp.htm')
 
 async function main () {
   console.log('Watching ' + input + ' and its directory tree.')
+  
+  const browserFetcher = puppeteer.createBrowserFetcher();
+  const revisionInfo = browserFetcher.revisionInfo(chromiumRevision);
   const browser = await puppeteer.launch({
-    headless: true
+    headless: true,
+    executablePath: revisionInfo.executablePath
   })
   const page = await browser.newPage()
   page.on('pageerror', function (err) {


### PR DESCRIPTION
This makes it easy to install this package and use an older version of chromium so that things like #17 work, but it's not very nice having to set the PUPPETEER_CHROMIUM_REVISION=526987 on install as well as in the package.json - not really sure if there is a better way.

To be honest, this might not be needed if someone can figure out why transform:rotate doesn't work, but I'll leave it here in case it helps.