### PR TITLE
Report actual version on the `relaxed --version` command.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const converters = require('./converters.js')
 
 var input, output
 
-const version = JSON.parse(fs.readFileSync('./package.json')).version
+const version = require('../package.json').version
 
 program
   .version(version)

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,10 @@ const converters = require('./converters.js')
 
 var input, output
 
+const version = JSON.parse(fs.readFileSync('./package.json')).version
+
 program
-  .version('0.0.1')
+  .version(version)
   .usage('<input> [output] [options]')
   .arguments('<input> [output] [options]')
   .option('--no-sandbox', 'disable puppeteer sandboxing')


### PR DESCRIPTION
This is better than reporting '0.0.1' for everything, or hardcoding it in
`src/index.js` since people might forget to update it on release.