### PR TITLE
Feat: Support pug locals as JSON console args

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ program
   .option('-w, --watch <locations>', 'Watch other locations', [])
   .option('-t, --temp [location]', 'Directory for temp file')
   .option('--bo, --build-once', 'Build once only, do not watch')
+  .option('-l, --locals <json>', 'Json locals for pug rendering')
   .action(function (inp, out) {
     input = inp
     output = out
@@ -75,6 +76,16 @@ const tempHTMLPath = path.join(tempDir, inputFilenameNoExt + '_temp.htm')
 let watchLocations = [inputDir]
 if (program.watch) {
   watchLocations = watchLocations.concat(program.watch)
+}
+
+let locals;
+if(program.locals) {
+  try {
+      locals = JSON.parse(JSON.parse(program.locals));
+  } catch(e) {
+    console.error(e);
+    colors.red('ReLaXed error: Could not parse locals JSON, see above.');
+  }
 }
 
 // Google Chrome headless configuration
@@ -183,7 +194,7 @@ async function build (filepath) {
   }
 
   if (!taskPromise) {
-    taskPromise = masterToPDF(inputPath, relaxedGlobals, tempHTMLPath, outputPath)
+    taskPromise = masterToPDF(inputPath, relaxedGlobals, tempHTMLPath, outputPath, locals)
   }
   await taskPromise
   var duration = ((performance.now() - t0) / 1000).toFixed(2)

--- a/src/masterToPDF.js
+++ b/src/masterToPDF.js
@@ -6,7 +6,7 @@ const filesize = require('filesize')
 const path = require('path')
 const { performance } = require('perf_hooks')
 
-exports.masterToPDF = async function (masterPath, relaxedGlobals, tempHTMLPath, outputPath) {
+exports.masterToPDF = async function (masterPath, relaxedGlobals, tempHTMLPath, outputPath, locals) {
   var t0 = performance.now()
   var page = relaxedGlobals.puppeteerPage
   /*
@@ -25,7 +25,7 @@ exports.masterToPDF = async function (masterPath, relaxedGlobals, tempHTMLPath, 
     try {
       var masterPug = fs.readFileSync(masterPath, 'utf8')
 
-      html = pug.render(pluginPugHeaders + '\n' + masterPug, {
+      html = pug.render(pluginPugHeaders + '\n' + masterPug, Object.assign({}, locals ? locals : {}, {
         filename: masterPath,
         fs: fs,
         cheerio: cheerio,
@@ -34,7 +34,7 @@ exports.masterToPDF = async function (masterPath, relaxedGlobals, tempHTMLPath, 
         require: require,
         performance: performance,
         filters: pugFilters
-      })
+      }))
     } catch (error) {
       console.log(error.message)
       console.error(colors.red('There was a Pug error (see above)'))


### PR DESCRIPTION
This PR adds the `--locals` flag which can be used to pass JSON locals parameters to pug.
This allows the compilation of templated pugs on the fly.