### PR TITLE
ci: test also on the latest LTS Node.js release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "lts/*"
   - "stable"
 
 before_install:


### PR DESCRIPTION
We should also test against Node.js 10 (latest LTS).