### PR TITLE
Sets table builtin plugin csv delimiter to auto

### DIFF
--- a/src/builtin_plugins/table/index.js
+++ b/src/builtin_plugins/table/index.js
@@ -19,7 +19,7 @@ exports.constructor = async function (params) {
 }
 
 var csvTtableToPug = async function (tablePath) {
-  const rows = await csv({output: 'csv', noheader: true}).fromFile(tablePath)
+  const rows = await csv({output: 'csv', noheader: true, delimiter: 'auto'}).fromFile(tablePath)
   console.log(rows)
   var extension, header
   if (tablePath.endsWith('.htable.csv')) {


### PR DESCRIPTION
My tables were tabulation separated, which is handled by the auto delimiter but not by the default, which is ","