### PR TITLE
Forward Plugin Parameters to mathjax-node-page

### DIFF
--- a/src/builtin_plugins/mathjax/index.js
+++ b/src/builtin_plugins/mathjax/index.js
@@ -4,18 +4,23 @@ const mjpage = require('mathjax-node-page')
 
 exports.constructor = async function (params) {
   return {
-    htmlModifiers: [ asyncMathjax ]
+    htmlModifiers: [asyncMathjax(params)]
   }
 }
 
-var asyncMathjax = async function (html) {
-  return new Promise(resolve => {
-    mjpage.mjpage(html, {
-      format: ['TeX']
-    }, {
-      mml: true,
-      css: true,
-      html: true
-    }, response => resolve(response))
-  })
-}
+var asyncMathjax =
+  (params) => {
+    console.log(params);
+    return async (html) => {
+      return new Promise(resolve => {
+        mjpage.mjpage(html, {
+          format: ['TeX'],
+          ...params
+        }, {
+          mml: true,
+          css: true,
+          html: true,
+        }, response => resolve(response))
+      })
+    }
+  }


### PR DESCRIPTION
Fixes #118.

Allows you to configure any options for mathjax-node-page in the config settings for the RelaXed plugin. For instance, to solve the need in #118:

**config.yml:**

```yaml
plugins:
  - mathjax:
      singleDollars: true
```