### PR TITLE
Fix --build-once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ async function main () {
 
   const buildError = await build(inputPath)
 
-  if (program.buildOnce) {
+  if (options.buildOnce) {
     process.exit(buildError ? 1 : 0)
   } else {
     watch()


### PR DESCRIPTION
Commandline args need to be accessed through options, not program.
This probably went wrong when merging in #196 and #194 at the same time.